### PR TITLE
INT-2541 Add shutdown support for NXRM

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
-﻿OpenShift/helm/nexus-iq/myvalues.yaml
-.idea/*
-OpenShift/helm/nexus-repository-manager/myvalues.yaml
+﻿**/myvalues.yaml
+**/.idea

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 ﻿OpenShift/helm/nexus-iq/myvalues.yaml
+.idea/*
+OpenShift/helm/nexus-repository-manager/myvalues.yaml

--- a/OpenShift/helm/nexus-repository-manager/README.md
+++ b/OpenShift/helm/nexus-repository-manager/README.md
@@ -36,17 +36,11 @@ Red Hat Certified Container (RHCC) requires authentication in order to pull the 
 ```bash
 cat service-auth.json | base64 > service.base64
 ```
-  4. Create a Secret file, eg `rhcc-pull-secret.yaml` using this base 64 string as:
+  4. Add this base64 encoded string to your `myvalues.yaml` file as `nexus.imagePullSecret`:
 
-```YAML
-apiVersion: v1
-kind: Secret
-metadata:
-  name: rhcc-pull-secret
-data:
-  .dockerconfigjson: {BASE64-DOCKER-CONFIG}
-
-type: kubernetes.io/dockerconfigjson
+```yaml
+nexus:
+  imagePullSecret: {BASE64_ENCODED_SECRET}
 ```
 
 Then this can be submitted to the cluster as:
@@ -78,7 +72,7 @@ $ helm install --dry-run --debug -f my_values.yaml ./
 To install the chart:
 
 ```bash
-$ helm install ./
+$ helm install -f myvalues.yaml ./
 ```
 
 If you are getting the error `Error: no available release name found` during
@@ -155,6 +149,8 @@ The following table lists the configurable parameters of the Nexus chart and the
 | `deployment.annotations`                    | Annotations to enhance deployment configuration  | `{}`                       |
 | `deployment.initContainers`                 | Init containers to run before main containers  | `nil`                        |
 | `deployment.postStart.command`              | Command to run after starting the nexus container  | `nil`                    |
+| `deployment.preStart.command`               | Command to run before starting the nexus container  | `nil`                   |
+| `deployment.terminationGracePeriodSeconds`  | Update termination grace period (in seconds)        | 120s                    |
 | `deployment.additionalContainers`           | Add additional Container         | `nil`                                      |
 | `deployment.additionalVolumes`              | Add additional Volumes           | `nil`                                      |
 | `deployment.additionalVolumeMounts`         | Add additional Volume mounts     | `nil`                                      |

--- a/OpenShift/helm/nexus-repository-manager/templates/deployment-statefulset.yaml
+++ b/OpenShift/helm/nexus-repository-manager/templates/deployment-statefulset.yaml
@@ -53,17 +53,25 @@ spec:
       {{- end }}
       {{- if .Values.nexus.imagePullSecret }}
       imagePullSecrets:
-        - name: {{ .Values.nexus.imagePullSecret }}
+        - name: {{ template "nexus.name" . }}
       {{- end }}
       containers:
         - name: nexus
           image: {{ .Values.nexus.imageName }}:{{ .Values.nexus.imageTag }}
           imagePullPolicy: {{ .Values.nexus.imagePullPolicy }}
-          {{- if .Values.deployment.postStart.command }}
+          {{- if .Values.deployment.terminationGracePeriodSeconds }}
+          terminationGracePeriodSeconds: {{ .Values.deployment.terminationGracePeriodSeconds }}
+          {{- end }}
           lifecycle:
+          {{- if .Values.deployment.postStart.command }}
             postStart:
               exec:
                 command: {{ .Values.deployment.postStart.command }}
+          {{- end }}
+          {{- if .Values.deployment.preStart.command }}
+            preStart:
+              exec:
+                command: {{ .Values.deployment.preStart.command }}
           {{- end }}
           env:
 {{ toYaml .Values.nexus.env | indent 12 }}

--- a/OpenShift/helm/nexus-repository-manager/templates/image-pull-secret.yaml
+++ b/OpenShift/helm/nexus-repository-manager/templates/image-pull-secret.yaml
@@ -1,0 +1,10 @@
+{{- if .Values.nexus.imagePullSecret -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "nexus.name" . }}
+data:
+  .dockerconfigjson: {{ .Values.nexus.imagePullSecret }}
+
+type: kubernetes.io/dockerconfigjson
+{{- end }}

--- a/OpenShift/helm/nexus-repository-manager/values.yaml
+++ b/OpenShift/helm/nexus-repository-manager/values.yaml
@@ -149,6 +149,9 @@ deployment:
   # # Uncomment and modify this to run a command after starting the nexus container.
   postStart:
     command:    # '["/bin/sh", "-c", "ls"]'
+  preStart:
+    command:    # '["/bin/rm", "-f", "/tmp/i4jdaemon__opt_nexus_nexus-3.20.0-04_bin_nexus"]'
+  terminationGracePeriodSeconds: 120
   additionalContainers:
   additionalVolumes:
   additionalVolumeMounts:

--- a/OpenShift/helm/nexus-repository-manager/values.yaml
+++ b/OpenShift/helm/nexus-repository-manager/values.yaml
@@ -150,7 +150,7 @@ deployment:
   postStart:
     command:    # '["/bin/sh", "-c", "ls"]'
   preStart:
-    command:    # '["/bin/rm", "-f", "/tmp/i4jdaemon__opt_nexus_nexus-3.20.0-04_bin_nexus"]'
+    command:    # '["/bin/rm", "-f", "/path/to/lockfile"]'
   terminationGracePeriodSeconds: 120
   additionalContainers:
   additionalVolumes:


### PR DESCRIPTION
Jira: https://issues.sonatype.org/browse/INT-2541

Added support for users to add hooks in startup to remove any stale lock files, if desired. It also adds support for an increased grace period as described in the sonatype help docs for docker images.

Also boyscoutted an improvement to the RHCC pull secret so that it can be easily added to the values file rather than being stored separately. This will allow `helm del --purge nxrm` during testing.