### PR TITLE
switching to clusterIP

### DIFF
--- a/OpenShift/helm/nexus-iq/Chart.yaml
+++ b/OpenShift/helm/nexus-iq/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.84.0
 description: A Helm chart for Kubernetes
 name: iqserver
-version: 0.1.0
+version: 0.1.1
 description: Sonatype Nexus IQ Server continuously monitors your entire software supply chain
 keywords:
   - sonatype

--- a/OpenShift/helm/nexus-iq/templates/service.yaml
+++ b/OpenShift/helm/nexus-iq/templates/service.yaml
@@ -10,4 +10,4 @@ spec:
     port: {{ .Values.iq.applicationPort }}
   - name: admin
     port: {{ .Values.iq.adminPort }}
-  type: NodePort
+  type: ClusterIP

--- a/OpenShift/helm/nexus-repository-manager/Chart.yaml
+++ b/OpenShift/helm/nexus-repository-manager/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: sonatype-nexus
-version: 0.2.0
+version: 0.2.1
 appVersion: 3.20.1-01
 description: Sonatype Nexus is an open source repository manager
 keywords:

--- a/OpenShift/helm/nexus-repository-manager/values.yaml
+++ b/OpenShift/helm/nexus-repository-manager/values.yaml
@@ -36,7 +36,7 @@ nexus:
   dockerPort: 5003
   nexusPort: 8081
   service:
-    type: NodePort
+    type: ClusterIP
     # clusterIP: None
   # annotations: {}
     ## When using LoadBalancer service type, use the following AWS certificate from ACM


### PR DESCRIPTION
Addressing issue #12 . ClusterIP is the preferred method and then it is easy to make a 'route' to the service in OCP