### PR TITLE
Combine image name tag

### DIFF
--- a/OpenShift/helm/nexus-iq/README.md
+++ b/OpenShift/helm/nexus-iq/README.md
@@ -42,7 +42,6 @@ cat service-auth.json | base64 > service.base64
 iq:
   name: nxiq
   imageName: registry.connect.redhat.com/sonatype/nexus-iq-server
-  imageTag: 1.85.0-01-ubi
   imagePullPolicy: IfNotPresent
   imagePullSecret: "{BASE64-DOCKER-CONFIG}"
 ```
@@ -107,8 +106,7 @@ The command removes all the Kubernetes components associated with the chart and 
 
 | Parameter            | Description                                                  | Default           |
 | -------------------- | ------------------------------------------------------------ | ----------------- |
-| `iq.imageName`       | The image name to use for the IQ Container, eg `sonatype/nexus-iq-server`  | `"registry.connect.redhat.com/sonatype/nexus-iq-server"`              |
-| `iq.imageTag`        | The image tag to use                                         | the latest tag, eg `"1.85.0-01-ubi"`              |
+| `iq.imageName`       | The image name to use for the IQ Container, eg `sonatype/nexus-iq-server`  | `"registry.connect.redhat.com/sonatype/nexus-iq-server:1.93.0-ubi-1"` |
 | `iq.imagePullSecret` | The base-64 encoded secret to pull a container from Red Hat  | `""`              |
 | `iq.applicationPort` | Port of the application connector. Must match the value in the `configYaml` property | `8070`            |
 | `iq.adminPort`       | Port of the application connector. Must match the value in the `configYaml` property | `8071`            |

--- a/OpenShift/helm/nexus-iq/README.md
+++ b/OpenShift/helm/nexus-iq/README.md
@@ -10,7 +10,7 @@
 
 ### With Open Docker Image
 
-By default, the Chart uses Red Hat's Certified Container. If you want to use the standard docker image, run with `--set iq.imageName=sonatype/nexus-iq-server`.
+By default, the Chart uses Red Hat's Certified Container. If you want to use the standard docker image, run with `--set iq.imageName=sonatype/nexus-iq-server:1.93.0`.
 
 ### With Red Hat Certified container
 

--- a/OpenShift/helm/nexus-iq/templates/deployment.yaml
+++ b/OpenShift/helm/nexus-iq/templates/deployment.yaml
@@ -20,7 +20,7 @@ spec:
       {{- end }}
       containers:
       - name: {{ template "iqserver.fullname" . }}
-        image: {{ .Values.iq.imageName }}:{{ .Values.iq.imageTag }}
+        image: {{ .Values.iq.imageName }}
         ports:
         - containerPort: {{ .Values.iq.applicationPort }}
         {{- if .Values.deployment.terminationGracePeriodSeconds }}

--- a/OpenShift/helm/nexus-iq/values.yaml
+++ b/OpenShift/helm/nexus-iq/values.yaml
@@ -4,8 +4,7 @@
 
 iq:
   name: nxiq
-  imageName: registry.connect.redhat.com/sonatype/nexus-iq-server
-  imageTag: 1.85.0-01-ubi
+  imageName: registry.connect.redhat.com/sonatype/nexus-iq-server:1.93.0-ubi-1
   imagePullPolicy: IfNotPresent
   imagePullSecret: ""
   applicationPort: 8070

--- a/OpenShift/helm/nexus-repository-manager/README.md
+++ b/OpenShift/helm/nexus-repository-manager/README.md
@@ -14,7 +14,7 @@ This chart bootstraps a Nexus OSS deployment on a cluster using Helm.
 
 ### With Open Docker Image
 
-By default, the Chart uses Red Hat's Certified Container. If you want to use the standard docker image, run with `--set nexus.imageName=sonatype/nexus3`.
+By default, the Chart uses Red Hat's Certified Container. If you want to use the standard docker image, run with `--set nexus.imageName=sonatype/nexus3:3.24.0`.
 
 ### With Red Hat Certified container
 

--- a/OpenShift/helm/nexus-repository-manager/templates/deployment-statefulset.yaml
+++ b/OpenShift/helm/nexus-repository-manager/templates/deployment-statefulset.yaml
@@ -57,7 +57,7 @@ spec:
       {{- end }}
       containers:
         - name: nexus
-          image: {{ .Values.nexus.imageName }}:{{ .Values.nexus.imageTag }}
+          image: {{ .Values.nexus.imageName }}
           imagePullPolicy: {{ .Values.nexus.imagePullPolicy }}
           {{- if .Values.deployment.terminationGracePeriodSeconds }}
           terminationGracePeriodSeconds: {{ .Values.deployment.terminationGracePeriodSeconds }}

--- a/OpenShift/helm/nexus-repository-manager/values.yaml
+++ b/OpenShift/helm/nexus-repository-manager/values.yaml
@@ -9,8 +9,7 @@ deploymentStrategy: {}
   # type: RollingUpdate
 
 nexus:
-  imageName: registry.connect.redhat.com/sonatype/nexus-repository-manager
-  imageTag: 3.21.1-01-ubi-23
+  imageName: registry.connect.redhat.com/sonatype/nexus-repository-manager:3.24.0-ubi-1
   imagePullPolicy: IfNotPresent
   imagePullSecret: ""
   env:


### PR DESCRIPTION
operators require imageName to include the tag instead of it being separate. This combines them here, while still allowing the user to specify image name and tag as a combined imageName field.