### PR TITLE
move terminationGracePeriodSeconds to right level

### DIFF
--- a/OpenShift/helm/nexus-iq/templates/deployment.yaml
+++ b/OpenShift/helm/nexus-iq/templates/deployment.yaml
@@ -18,14 +18,14 @@ spec:
       imagePullSecrets:
         - name: {{ template "iqserver.fullname" . }}-imagepull
       {{- end }}
+      {{- if .Values.deployment.terminationGracePeriodSeconds }}
+      terminationGracePeriodSeconds: {{ .Values.deployment.terminationGracePeriodSeconds }}
+      {{- end }}
       containers:
       - name: {{ template "iqserver.fullname" . }}
         image: {{ .Values.iq.imageName }}
         ports:
         - containerPort: {{ .Values.iq.applicationPort }}
-        {{- if .Values.deployment.terminationGracePeriodSeconds }}
-        terminationGracePeriodSeconds: {{ .Values.deployment.terminationGracePeriodSeconds }}
-        {{- end }}
         lifecycle:
           {{- if .Values.deployment.postStart.command }}
           postStart:

--- a/OpenShift/helm/nexus-repository-manager/templates/deployment-statefulset.yaml
+++ b/OpenShift/helm/nexus-repository-manager/templates/deployment-statefulset.yaml
@@ -55,13 +55,13 @@ spec:
       imagePullSecrets:
         - name: {{ template "nexus.name" . }}
       {{- end }}
+      {{- if .Values.deployment.terminationGracePeriodSeconds }}
+      terminationGracePeriodSeconds: {{ .Values.deployment.terminationGracePeriodSeconds }}
+      {{- end }}
       containers:
         - name: nexus
           image: {{ .Values.nexus.imageName }}
           imagePullPolicy: {{ .Values.nexus.imagePullPolicy }}
-          {{- if .Values.deployment.terminationGracePeriodSeconds }}
-          terminationGracePeriodSeconds: {{ .Values.deployment.terminationGracePeriodSeconds }}
-          {{- end }}
           lifecycle:
           {{- if .Values.deployment.postStart.command }}
             postStart:


### PR DESCRIPTION
It existed at the wrong level in the yaml, which caused failures in some environments (operators in particular).
https://cloud.google.com/blog/products/gcp/kubernetes-best-practices-terminating-with-grace